### PR TITLE
Add peer certificates for mtls to Warp 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ percent-encoding = "2.1"
 pin-project = "1.0"
 tokio-rustls = { version = "0.25", optional = true }
 rustls-pemfile = { version = "2.0", optional = true }
+rustls-pki-types = { version = "1.9.0", optional = true }
 
 [dev-dependencies]
 pretty_env_logger = "0.5"
@@ -56,7 +57,7 @@ listenfd = "1.0"
 default = ["multipart", "websocket"]
 multipart = ["multer"]
 websocket = ["tokio-tungstenite"]
-tls = ["tokio-rustls", "rustls-pemfile"]
+tls = ["tokio-rustls", "rustls-pemfile", "rustls-pki-types"]
 
 # Enable compression-related filters
 compression = ["compression-brotli", "compression-gzip"]

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -22,6 +22,8 @@ pub mod path;
 pub mod query;
 pub mod reply;
 pub mod sse;
+#[cfg(feature = "tls")]
+pub mod mtls;
 pub mod trace;
 #[cfg(feature = "websocket")]
 pub mod ws;

--- a/src/filters/mtls.rs
+++ b/src/filters/mtls.rs
@@ -2,12 +2,15 @@
 
 use std::convert::Infallible;
 
-use tokio_rustls::rustls::Certificate;
+use rustls_pki_types::CertificateDer;
 
 use crate::{
     filter::{filter_fn_one, Filter},
     route::Route,
 };
+
+/// Certificates is a iterable container of Certificates.
+pub type Certificates = Vec<CertificateDer<'static>>;
 
 /// Creates a `Filter` to get the peer certificates for the TLS connection.
 ///
@@ -27,35 +30,23 @@ use crate::{
 /// ```
 pub fn peer_certificates(
 ) -> impl Filter<Extract = (Option<Certificates>,), Error = Infallible> + Copy {
-    filter_fn_one(|route| futures_util::future::ok(Certificates::from_route(route)))
+    filter_fn_one(|route| futures_util::future::ok(from_route(route)))
 }
 
-/// Certificates is a iterable container of Certificates.
-#[derive(Debug)]
-pub struct Certificates(Vec<Certificate>);
-
-impl Certificates {
-    fn from_route(route: &Route) -> Option<Certificates> {
-        route
-            .peer_certificates()
-            .read()
-            .unwrap()
-            .as_ref()
-            .map(|certs| Self(certs.to_vec()))
-    }
+/// Utility method for taking ownership of the peer certificates.
+pub fn peer_certs_into_owned(certs: &Vec<CertificateDer<'_>>) -> Vec<CertificateDer<'static>> {
+    certs
+        .to_vec()
+        .iter()
+        .map(|cert| cert.clone().into_owned())
+        .collect()
 }
 
-impl AsRef<[Certificate]> for Certificates {
-    fn as_ref(&self) -> &[Certificate] {
-        self.0.as_ref()
-    }
-}
-
-impl<'a> IntoIterator for &'a Certificates {
-    type Item = &'a Certificate;
-    type IntoIter = std::slice::Iter<'a, Certificate>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter()
-    }
+fn from_route(route: &Route) -> Option<Certificates> {
+    route
+        .peer_certificates()
+        .read()
+        .unwrap()
+        .as_ref()
+        .map(peer_certs_into_owned)
 }

--- a/src/filters/mtls.rs
+++ b/src/filters/mtls.rs
@@ -1,0 +1,61 @@
+//! Mutual (client) TLS filters.
+
+use std::convert::Infallible;
+
+use tokio_rustls::rustls::Certificate;
+
+use crate::{
+    filter::{filter_fn_one, Filter},
+    route::Route,
+};
+
+/// Creates a `Filter` to get the peer certificates for the TLS connection.
+///
+/// If the underlying transport doesn't have peer certificates, this will yield
+/// `None`.
+///
+/// # Example
+///
+/// ```
+/// use warp::mtls::Certificates;
+/// use warp::Filter;
+///
+/// let route = warp::mtls::peer_certificates()
+///     .map(|certs: Option<Certificates>| {
+///         println!("peer certificates = {:?}", certs.as_ref());
+///     });
+/// ```
+pub fn peer_certificates(
+) -> impl Filter<Extract = (Option<Certificates>,), Error = Infallible> + Copy {
+    filter_fn_one(|route| futures_util::future::ok(Certificates::from_route(route)))
+}
+
+/// Certificates is a iterable container of Certificates.
+#[derive(Debug)]
+pub struct Certificates(Vec<Certificate>);
+
+impl Certificates {
+    fn from_route(route: &Route) -> Option<Certificates> {
+        route
+            .peer_certificates()
+            .read()
+            .unwrap()
+            .as_ref()
+            .map(|certs| Self(certs.to_vec()))
+    }
+}
+
+impl AsRef<[Certificate]> for Certificates {
+    fn as_ref(&self) -> &[Certificate] {
+        self.0.as_ref()
+    }
+}
+
+impl<'a> IntoIterator for &'a Certificates {
+    type Item = &'a Certificate;
+    type IntoIter = std::slice::Iter<'a, Certificate>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,9 @@ pub use self::filters::compression;
 #[cfg(feature = "multipart")]
 #[doc(hidden)]
 pub use self::filters::multipart;
+#[cfg(feature = "tls")]
+#[doc(hidden)]
+pub use self::filters::mtls;
 #[cfg(feature = "websocket")]
 #[doc(hidden)]
 pub use self::filters::ws;

--- a/src/server.rs
+++ b/src/server.rs
@@ -55,9 +55,14 @@ macro_rules! into_service {
         let inner = crate::service($into);
         make_service_fn(move |transport| {
             let inner = inner.clone();
-            let remote_addr = Transport::remote_addr(transport);
+
+            let peer_info = crate::transport::PeerInfo {
+                remote_addr: Transport::remote_addr(transport),
+                peer_certificates: Transport::peer_certificates(transport),
+            };
+
             future::ok::<_, Infallible>(service_fn(move |req| {
-                inner.call_with_addr(req, remote_addr)
+                inner.call_with_peer_info(req, peer_info.clone())
             }))
         })
     }};

--- a/src/test.rs
+++ b/src/test.rs
@@ -113,10 +113,13 @@ use crate::filters::ws::Message;
 use crate::reject::IsReject;
 use crate::reply::Reply;
 use crate::route::{self, Route};
-use crate::Request;
 use crate::transport::PeerInfo;
+use crate::Request;
 #[cfg(feature = "websocket")]
 use crate::{Sink, Stream};
+
+#[cfg(feature = "tls")]
+use crate::filters::mtls::Certificates;
 
 use self::inner::OneOrTuple;
 
@@ -256,10 +259,10 @@ impl RequestBuilder {
     /// # Example
     /// ```
     /// let req = warp::test::request()
-    ///     .peer_certificates([tokio_rustls::rustls::Certificate(b"FAKE CERT".to_vec())]);
+    ///     .peer_certificates([rustls_pki_types::CertificateDer::from_slice(b"FAKE CERT")]);
     /// ```
     #[cfg(feature = "tls")]
-    pub fn peer_certificates(self, certs: impl Into<Vec<tokio_rustls::rustls::Certificate>>) -> Self {
+    pub fn peer_certificates(self, certs: impl Into<Certificates>) -> Self {
         *self.peer_info.peer_certificates.write().unwrap() = Some(certs.into());
         self
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -114,6 +114,7 @@ use crate::reject::IsReject;
 use crate::reply::Reply;
 use crate::route::{self, Route};
 use crate::Request;
+use crate::transport::PeerInfo;
 #[cfg(feature = "websocket")]
 use crate::{Sink, Stream};
 
@@ -121,10 +122,7 @@ use self::inner::OneOrTuple;
 
 /// Starts a new test `RequestBuilder`.
 pub fn request() -> RequestBuilder {
-    RequestBuilder {
-        remote_addr: None,
-        req: Request::default(),
-    }
+    Default::default()
 }
 
 /// Starts a new test `WsBuilder`.
@@ -137,9 +135,9 @@ pub fn ws() -> WsBuilder {
 ///
 /// See [module documentation](crate::test) for an overview.
 #[must_use = "RequestBuilder does nothing on its own"]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct RequestBuilder {
-    remote_addr: Option<SocketAddr>,
+    peer_info: PeerInfo,
     req: Request,
 }
 
@@ -248,7 +246,21 @@ impl RequestBuilder {
     ///     .remote_addr(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080));
     /// ```
     pub fn remote_addr(mut self, addr: SocketAddr) -> Self {
-        self.remote_addr = Some(addr);
+        self.peer_info.remote_addr = Some(addr);
+        self
+    }
+
+    /// Set the peer certificates of this request.
+    /// Default is no peer certificates.
+    ///
+    /// # Example
+    /// ```
+    /// let req = warp::test::request()
+    ///     .peer_certificates([tokio_rustls::rustls::Certificate(b"FAKE CERT".to_vec())]);
+    /// ```
+    #[cfg(feature = "tls")]
+    pub fn peer_certificates(self, certs: impl Into<Vec<tokio_rustls::rustls::Certificate>>) -> Self {
+        *self.peer_info.peer_certificates.write().unwrap() = Some(certs.into());
         self
     }
 
@@ -375,7 +387,7 @@ impl RequestBuilder {
         // TODO: de-duplicate this and apply_filter()
         assert!(!route::is_set(), "nested test filter calls");
 
-        let route = Route::new(self.req, self.remote_addr);
+        let route = Route::new(self.req, self.peer_info);
         let mut fut = Box::pin(
             route::set(&route, move || f.filter(crate::filter::Internal)).then(|result| {
                 let res = match result {
@@ -404,7 +416,7 @@ impl RequestBuilder {
     {
         assert!(!route::is_set(), "nested test filter calls");
 
-        let route = Route::new(self.req, self.remote_addr);
+        let route = Route::new(self.req, self.peer_info);
         let mut fut = Box::pin(route::set(&route, move || {
             f.filter(crate::filter::Internal)
         }));

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -287,7 +287,7 @@ impl Transport for TlsStream {
     }
 
     fn peer_certificates(&self) -> PeerCertificates {
-        self.peer_certs.clone()
+        Arc::clone(&self.peer_certs)
     }
 }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -7,7 +7,10 @@ use hyper::server::conn::AddrStream;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 #[cfg(feature = "tls")]
-pub(crate) type PeerCertificates = std::sync::Arc<std::sync::RwLock<Option<Vec<tokio_rustls::rustls::Certificate>>>>;
+use crate::filters::mtls::Certificates;
+
+#[cfg(feature = "tls")]
+pub(crate) type PeerCertificates = std::sync::Arc<std::sync::RwLock<Option<Certificates>>>;
 #[cfg(not(feature = "tls"))]
 pub(crate) type PeerCertificates = ();
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -6,8 +6,24 @@ use std::task::{Context, Poll};
 use hyper::server::conn::AddrStream;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
+#[cfg(feature = "tls")]
+pub(crate) type PeerCertificates = std::sync::Arc<std::sync::RwLock<Option<Vec<tokio_rustls::rustls::Certificate>>>>;
+#[cfg(not(feature = "tls"))]
+pub(crate) type PeerCertificates = ();
+
 pub trait Transport: AsyncRead + AsyncWrite {
     fn remote_addr(&self) -> Option<SocketAddr>;
+
+    fn peer_certificates(&self) -> PeerCertificates {
+        Default::default()
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PeerInfo {
+    pub remote_addr: Option<SocketAddr>,
+    #[allow(dead_code)]
+    pub peer_certificates: PeerCertificates,
 }
 
 impl Transport for AddrStream {

--- a/tests/mtls.rs
+++ b/tests/mtls.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 #![cfg(feature = "tls")]
 
-use tokio_rustls::rustls::Certificate;
+use rustls_pki_types::CertificateDer;
 
 #[tokio::test]
 async fn peer_certificates_missing() {
@@ -16,11 +16,9 @@ async fn peer_certificates_missing() {
 async fn peer_certificates_present() {
     let extract_peer_certs = warp::mtls::peer_certificates();
 
-    let cert = Certificate(b"TEST CERT".to_vec());
+    let cert = CertificateDer::<'_>::from_slice(b"TEST CERT");
+
     let req = warp::test::request().peer_certificates([cert.clone()]);
     let resp = req.filter(&extract_peer_certs).await.unwrap();
-    assert_eq!(
-        resp.unwrap().as_ref(),
-        &[cert],
-    )
+    assert_eq!(resp.unwrap(), &[cert],)
 }

--- a/tests/mtls.rs
+++ b/tests/mtls.rs
@@ -1,0 +1,26 @@
+#![deny(warnings)]
+#![cfg(feature = "tls")]
+
+use tokio_rustls::rustls::Certificate;
+
+#[tokio::test]
+async fn peer_certificates_missing() {
+    let extract_peer_certs = warp::mtls::peer_certificates();
+
+    let req = warp::test::request();
+    let resp = req.filter(&extract_peer_certs).await.unwrap();
+    assert!(resp.is_none())
+}
+
+#[tokio::test]
+async fn peer_certificates_present() {
+    let extract_peer_certs = warp::mtls::peer_certificates();
+
+    let cert = Certificate(b"TEST CERT".to_vec());
+    let req = warp::test::request().peer_certificates([cert.clone()]);
+    let resp = req.filter(&extract_peer_certs).await.unwrap();
+    assert_eq!(
+        resp.unwrap().as_ref(),
+        &[cert],
+    )
+}


### PR DESCRIPTION
This adds support for accessing the peer certificates of a valid mtls connection in warp.

Note that this is a cherry-pick of https://github.com/seanmonstar/warp/pull/942 updated to work on tip-of-tree warp.